### PR TITLE
Changes so that notes can be previewed in a default web browser

### DIFF
--- a/src/net/sf/memoranda/util/Util.java
+++ b/src/net/sf/memoranda/util/Util.java
@@ -122,6 +122,7 @@ public class Util {
 	 */
 	public static URI convertURLtoURI(String url) {
 		URI uri;
+		url = url.replace('\\', '/');
 		try {
 			uri = java.net.URI.create(url);
 		} catch (Exception e) {


### PR DESCRIPTION
These changes made it so that when the user clicks the button  "preview note in browser" a default web browser is automatically selected and the file string is converted so that the web browser can open the file.
